### PR TITLE
Fix build for Yosemite

### DIFF
--- a/Makefile.userprog
+++ b/Makefile.userprog
@@ -22,7 +22,7 @@ lib/user_SRC += lib/user/console.c	# Console code.
 
 LIB_OBJ = $(patsubst %.c,%.o,$(patsubst %.S,%.o,$(lib_SRC) $(lib/user_SRC)))
 LIB_DEP = $(patsubst %.o,%.d,$(LIB_OBJ))
-LIB = lib/user/entry.o libc.a
+LIB = lib/user/entry.o $(LIB_OBJ)
 
 PROGS_SRC = $(foreach prog,$(PROGS),$($(prog)_SRC))
 PROGS_OBJ = $(patsubst %.c,%.o,$(patsubst %.S,%.o,$(PROGS_SRC)))
@@ -38,14 +38,9 @@ endef
 
 $(foreach prog,$(PROGS),$(eval $(call TEMPLATE,$(prog))))
 
-libc.a: $(LIB_OBJ)
-	rm -f $@
-	ar r $@ $^
-	ranlib $@
-
 clean::
 	rm -f $(PROGS) $(PROGS_OBJ) $(PROGS_DEP)
-	rm -f $(LIB_DEP) $(LIB_OBJ) lib/user/entry.[do] libc.a 
+	rm -f $(LIB_DEP) $(LIB_OBJ) lib/user/entry.[do]
 
 .PHONY: all clean
 

--- a/README.md
+++ b/README.md
@@ -14,30 +14,33 @@ Pintos initial code to successfully compile and simulate on Mac using QEMU i386 
 For more documentation, refer to [Pintos Documentation Homepage](http://www.scs.stanford.edu/12au-cs140/pintos/pintos.html)
 
 ## Prerequisites ##
-1. Mac OS X Mavericks 
+1. Mac OS X Mavericks or higher
 2. [Homebrew](http://brew.sh/)
 
 ## Setting up your environment ##
-1. Install qemu
- * brew install qemu
-2. Install i386-elf-gcc and i386-elf-gdb cross compiler toolchain 
- * brew install homebrew/versions/gcc49
- * brew tap altkatz/gcc_cross_compilers
- * brew install altkatz/gcc_cross_compilers/i386-elf-gcc
- * brew install altkatz/gcc_cross_compilers/i386-elf-gdb
+1. Install QEMU 1.6.1. Pintos doesn't shutdown properly on later versions of QEMU, causing tests to fail. If QEMU is already installed, you may need to run `brew unlink qemu` first.
 
-## Changes on pintos source ##
- * devices/shutdown.c:shutdown_power_off
+```
+brew install https://raw.githubusercontent.com/Homebrew/homebrew/234a17f37faaedc007ceb2bae856edaaff3dc08f/Library/Formula/qemu.rb
+```
 
-   Added ACPI shutdown sequence to work with higher versions of QEMU simulator. Refer to http://forum.osdev.org/viewtopic.php?t=16990 for more information.
- * Make.config 
+2. Install i386-elf-gcc and i386-elf-gdb cross compiler toolchain.
 
-   Set compiler to i386-elf-gcc
- * threads/Make.vars
+```
+brew install homebrew/versions/gcc49
+brew install altkatz/gcc_cross_compilers/i386-elf-gcc
+brew install altkatz/gcc_cross_compilers/i386-elf-gdb
+```
 
-   SIMULATOR=--qemu to force qemu on make check.
- 
- 
+## Changes to pintos source ##
+* `devices/shutdown.c:shutdown_power_off`
 
+	* Added ACPI shutdown sequence to work with higher versions of QEMU simulator. Refer to http://forum.osdev.org/viewtopic.php?t=16990 for more information. This does not work in versions of QEMU later than 1.6.1.
 
+* `Make.config `
 
+	* Set compiler to i386-elf-gcc.
+
+* `threads/Make.vars`
+
+	* Set `SIMULATOR=--qemu` to force qemu on `make check`.

--- a/README.md
+++ b/README.md
@@ -18,10 +18,10 @@ For more documentation, refer to [Pintos Documentation Homepage](http://www.scs.
 2. [Homebrew](http://brew.sh/)
 
 ## Setting up your environment ##
-1. Install QEMU 1.6.1. Pintos doesn't shutdown properly on later versions of QEMU, causing tests to fail. If QEMU is already installed, you may need to run `brew unlink qemu` first.
+1. Install QEMU. Make sure you are using QEMU 2.0.0 or greater or Pintos may not shut down correctly.
 
 ```
-brew install https://raw.githubusercontent.com/Homebrew/homebrew/234a17f37faaedc007ceb2bae856edaaff3dc08f/Library/Formula/qemu.rb
+brew install qemu
 ```
 
 2. Install i386-elf-gcc and i386-elf-gdb cross compiler toolchain.
@@ -35,7 +35,7 @@ brew install altkatz/gcc_cross_compilers/i386-elf-gdb
 ## Changes to pintos source ##
 * `devices/shutdown.c:shutdown_power_off`
 
-	* Added ACPI shutdown sequence to work with higher versions of QEMU simulator. Refer to http://forum.osdev.org/viewtopic.php?t=16990 for more information. This does not work in versions of QEMU later than 1.6.1.
+	* Added ACPI shutdown sequence to work with higher versions of QEMU simulator. Refer to http://forum.osdev.org/viewtopic.php?t=16990 for more information.
 
 * `Make.config `
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ## Pintos on Mac ##
 Pintos Mac - Pintos on Mac
 
-Contact: 
+Contact:
 
 Jeremy Mao(maojie[AT]me.com or yujie.mao[AT]intel.com)
 
@@ -21,9 +21,10 @@ For more documentation, refer to [Pintos Documentation Homepage](http://www.scs.
 1. Install qemu
  * brew install qemu
 2. Install i386-elf-gcc and i386-elf-gdb cross compiler toolchain 
- * brew tap jinmel/gcc_cross_compilers
- * brew install jinmel/gcc_cross_compilers/i386-elf-gcc
- * brew install jinmel/gcc_cross_compilers/i386-elf-gdb
+ * brew install homebrew/versions/gcc49
+ * brew tap altkatz/gcc_cross_compilers
+ * brew install altkatz/gcc_cross_compilers/i386-elf-gcc
+ * brew install altkatz/gcc_cross_compilers/i386-elf-gdb
 
 ## Changes on pintos source ##
  * devices/shutdown.c:shutdown_power_off

--- a/devices/shutdown.c
+++ b/devices/shutdown.c
@@ -101,7 +101,7 @@ shutdown_power_off (void)
 
   /* ACPI Shutdown sequence supported by Bochs and QEMU
      http://forum.osdev.org/viewtopic.php?t=16990  */
-  outw( 0xB004, 0x0 | 0x2000 );
+  outw( 0x604, 0x0 | 0x2000 );
 
   /* This is a special power-off sequence supported by Bochs and
      QEMU, but not by physical hardware. */

--- a/utils/pintos
+++ b/utils/pintos
@@ -100,7 +100,7 @@ sub parse_command_line {
 	  or exit 1;
     }
 
-    $sim = "bochs" if !defined $sim;
+    $sim = "qemu" if !defined $sim;
     $debug = "none" if !defined $debug;
     $vga = exists ($ENV{DISPLAY}) ? "window" : "none" if !defined $vga;
 
@@ -126,8 +126,8 @@ Usage: pintos [OPTION...] -- [ARGUMENT...]
 where each OPTION is one of the following options
   and each ARGUMENT is passed to Pintos kernel verbatim.
 Simulator selection:
-  --bochs                  (default) Use Bochs as simulator
-  --qemu                   Use QEMU as simulator
+  --bochs                  Use Bochs as simulator
+  --qemu                   (default) Use QEMU as simulator
   --player                 Use VMware Player as simulator
 Debugger selection:
   --no-debug               (default) No debugger

--- a/utils/pintos
+++ b/utils/pintos
@@ -851,7 +851,7 @@ sub xsystem {
 	alarm (0);
 	&$cleanup ();
 
-	if (WIFSIGNALED ($?) && WTERMSIG ($?) == SIGVTALRM ()) {
+	if (WIFSIGNALED ($?) && WTERMSIG ($?) == SIGVTALRM2 ()) {
 	    seek (STDOUT, 0, 2);
 	    print "\nTIMEOUT after $timeout seconds of host CPU time\n";
 	    exit 0;
@@ -922,7 +922,7 @@ sub exec_setitimer {
     exit (1);
 }
 
-sub SIGVTALRM {
+sub SIGVTALRM2 {
     use Config;
     my $i = 0;
     foreach my $name (split(' ', $Config{sig_name})) {

--- a/utils/pintos-gdb
+++ b/utils/pintos-gdb
@@ -1,7 +1,7 @@
 #! /bin/sh
 
 # Path to GDB macros file.  Customize for your site.
-GDBMACROS=/usr/class/cs140/pintos/pintos/src/misc/gdb-macros
+GDBMACROS=$(dirname $0)/../misc/gdb-macros
 
 # Choose correct GDB.
 if command -v i386-elf-gdb >/dev/null 2>&1; then

--- a/utils/squish-pty.c
+++ b/utils/squish-pty.c
@@ -7,7 +7,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <stropts.h>
 #include <sys/ioctl.h>
 #include <sys/stat.h>
 #include <sys/time.h>
@@ -288,13 +287,15 @@ main (int argc __attribute__ ((unused)), char *argv[])
     fail_io ("open \"%s\"", name);
 
   /* System V implementations need STREAMS configuration for the
-     slave. */
+     slave. This is commented out as OS X doesn't provide stropts.h.
+
   if (isastream (slave))
     {
       if (ioctl (slave, I_PUSH, "ptem") < 0
           || ioctl (slave, I_PUSH, "ldterm") < 0)
         fail_io ("ioctl");
     }
+  */
 
   /* Arrange to get notified when a child dies, by writing a byte
      to a pipe fd.  We really want to use pselect() and

--- a/utils/squish-pty.c
+++ b/utils/squish-pty.c
@@ -91,7 +91,7 @@ handle_error (ssize_t retval, int *fd, bool fd_is_pty, const char *call)
               return false;
             }
           else
-            fail_io (call); 
+            fail_io ("%s", call); 
         }
       else
         return true;
@@ -105,7 +105,7 @@ handle_error (ssize_t retval, int *fd, bool fd_is_pty, const char *call)
           return true;
         }
       else
-        fail_io (call);
+        fail_io ("%s", call);
     }
 }
 

--- a/utils/squish-unix.c
+++ b/utils/squish-unix.c
@@ -8,7 +8,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <stropts.h>
 #include <sys/ioctl.h>
 #include <sys/stat.h>
 #include <sys/time.h>

--- a/utils/squish-unix.c
+++ b/utils/squish-unix.c
@@ -95,7 +95,7 @@ handle_error (ssize_t retval, int *fd, bool fd_is_sock, const char *call)
         }
     }
   else
-    fail_io (call); 
+    fail_io ("%s", call); 
 }
 
 /* Copies data from stdin to SOCK and from SOCK to stdout until no


### PR DESCRIPTION
Fixes the build of `userprog`, `vm`, and `filesys` for OS X Yosemite.
- Updates Homebrew formula to use versions of `i386-elf-gcc` etc. that build on Yosemite. This uses `homebrew/versions/gcc49`.
- Fixes build errors by replacing the use of `libc.a` in `Makefile.userprog` with the object files themselves. Not sure why `ld` isn't reading the symbols from `libc.a` but this fix seems to work.

This should fix most of the issues described in https://github.com/maojie/pintos_mac/pull/2.
